### PR TITLE
dropdown menu's text is invisible when navbar is stick to top

### DIFF
--- a/css/clean-blog.css
+++ b/css/clean-blog.css
@@ -63,6 +63,13 @@ hr.small {
   font-weight: 800;
   letter-spacing: 1px;
 }
+.nav .dropdown .dropdown-menu a {
+  color: black;
+}
+.nav .dropdown .dropdown-menu a:hover,
+.nav .dropdown .dropdown-menu a:focus {
+  color: #0085a1;
+}
 @media only screen and (min-width: 768px) {
   .navbar-custom {
     background: transparent;


### PR DESCRIPTION
Greeting,
  Nice template for bootstrap rookies!
  I notice that when navbar is stick to top, the text is white and the background is transparent. But the background color of navbar's dropdown menu is white too, which makes the text invisible.
  I fixed it up with the default color-schema used in other places of the template.